### PR TITLE
Minor accessibility improvement for focus state

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,9 @@ export const copyToClipboard = (content: string, richHtml = false) => {
   if (!richHtml && navigator.clipboard) {
     return navigator.clipboard.writeText(content);
   }
+  
+  const activeEl = document.activeElement
+  
   const textArea = document.createElement('textarea');
   textArea.style.maxHeight = '0';
   textArea.style.height = '0';
@@ -28,6 +31,8 @@ export const copyToClipboard = (content: string, richHtml = false) => {
   } else {
     copy();
   }
+  
+  activeEl && activeEl.focus()
 
   document.body.removeChild(textArea);
 };


### PR DESCRIPTION
This code depends on creating a textarea, focusing on it, copying, then removing the textarea from the DOM. In doing so, the focus state will be passed to the textarea, and then lost. By tracking the document's active element and then focusing back to it after the copy, we can maintain a predictable focus state for users that rely on keyboard navigation. SWEET!